### PR TITLE
Add table-driven tests for date normalization

### DIFF
--- a/pkg/filedates/filedates_test.go
+++ b/pkg/filedates/filedates_test.go
@@ -22,12 +22,26 @@ func TestParseDate(t *testing.T) {
 }
 
 func TestFixDateInString(t *testing.T) {
-	got, err := FixDateInString("report_12-31-2022.txt")
-	if err != nil {
-		t.Fatalf("FixDateInString returned error: %v", err)
+	cases := []struct {
+		input  string
+		expect string
+	}{
+		{"report_31-12-2022.txt", "report_2022-12-31.txt"},
+		{"report_12-31-2022.txt", "report_2022-12-31.txt"},
+		{"report_2022-12-31.txt", "report_2022-12-31.txt"},
+		{"report_22-12-31.txt", "report_2022-12-31.txt"},
+		{"report_12-31-22.txt", "report_2022-12-31.txt"},
+		{"notes 01-02-2022.md", "notes 2022-02-01.md"},
+		{"notes 02-01-2022.md", "notes 2022-01-02.md"},
 	}
-	expect := "report_2022-12-31.txt"
-	if got != expect {
-		t.Fatalf("expected %s, got %s", expect, got)
+
+	for _, c := range cases {
+		got, err := FixDateInString(c.input)
+		if err != nil {
+			t.Fatalf("FixDateInString(%s) returned error: %v", c.input, err)
+		}
+		if got != c.expect {
+			t.Fatalf("FixDateInString(%s) = %s, want %s", c.input, got, c.expect)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- convert `TestFixDateInString` to table driven tests
- test multiple YMD layouts and ambiguous inputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68559c2145548331ba06c23362ea5fc1